### PR TITLE
Escape `pattern` before creating a regular expression from it

### DIFF
--- a/lib/languages.rb
+++ b/lib/languages.rb
@@ -34,7 +34,7 @@ module Languages
     end
 
     def search(pattern, case_sensitive: true)
-      pattern = Regexp.new(pattern, Regexp::IGNORECASE).freeze unless case_sensitive
+      pattern = Regexp.new(Regexp.escape(pattern), Regexp::IGNORECASE).freeze unless case_sensitive
       all.select { |l| l.name.match? pattern }
     end
 


### PR DESCRIPTION
By creating a regular expression from what might be user input we are
allowing the system to run arbitrary regular expressions, which could be
a security concern.

We can simply escape it to avoid potential problems. Benchmarking shows
that this runs comparatively quickly:

```
            original      1.822k (± 1.8%) i/s  (548.72 μs/i) -      9.150k in   5.022464s
             escaped      1.813k (± 5.4%) i/s  (551.64 μs/i) -      9.180k in   5.085108s
```